### PR TITLE
:arrow_up: Bump package deps from Suggests to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrEfficient
 Title: Jumping Rivers: Efficient R Programming
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: 
     person(given = "Colin",
            family = "Gillespie",
@@ -23,17 +23,17 @@ Imports:
     bench,
     benchmarkme,
     dplyr,
+    ggbeeswarm,
+    ggplot2,
     lobstr,
-    readr
+    readr,
+    tidyr
 Suggests:
     formatR,
     fortunes,
-    ggbeeswarm,
-    ggplot2,
     knitr,
     lintr,
     testthat,
-    tidyr,
     tufte
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # jrEfficient 0.1.8 _2020-09-17_
 
-  * Bump ggbeeswarm, ggplot2, tidyr from Suggests to Depends
+  * Bump ggbeeswarm, ggplot2, tidyr from Suggests to Imports
 
 # jrEfficient 0.1.7 _2020-09-11_
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrEfficient 0.1.8 _2020-09-17_
+
+  * Bump ggbeeswarm, ggplot2, tidyr from Suggests to Depends
+
 # jrEfficient 0.1.7 _2020-09-11_
 
   * Update course dependencies


### PR DESCRIPTION
One of our practicals requires attendees to use `ggplot2::autoplot()` on {bench} data frames.

{ggplot2}, {ggbeeswarm} and {tidyr} are all required in order for ggplot2::autoplot to work on {bench} data frames.

